### PR TITLE
Try to bump up marketplace search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-linthtml",
-  "displayName": "LintHTML",
+  "displayName": "Lint HTML",
   "description": "Bring LintHTML errors into vscode",
   "author": "Benjamin JEGARD",
   "publisher": "kamikillerto",


### PR DESCRIPTION
Marketplace search is kind of bad, and now when you search `lint html` your extension at about ~200th place in the result. I think changing the display name might change that. Extension id stays the same and this is NOT a breaking change.

You can even go further and experiment to give it a name that might produce a better result:

- `html lint`
- `lint html`
- `lint html / html lint`

And look at the results at the marketplace.